### PR TITLE
test: Add tests for escapeChars

### DIFF
--- a/src/tests/test.index.js
+++ b/src/tests/test.index.js
@@ -1,11 +1,23 @@
 // coverage coming soon, just user tested right now
 const assert = require('chai').assert;
 const styled = require('../index.js').default;
+const escapeChars = require('../index.js').escapeChars;
 
 describe('should function normally', () => {
   it('should construct normally', () => {
     assert.equal(typeof styled, 'function');
     assert.equal(typeof styled.div, 'function');
     assert.equal(typeof styled.button, 'function');
+  });
+});
+
+describe('escapeChars', () => {
+  it('removes dangerous characters', () => {
+    assert.equal(escapeChars('&<>"\''), '');
+  });
+
+  it('does not remove non-dangerous characters', () => {
+    const safeString = 'This string contains only safe characters.';
+    assert.equal(escapeChars(safeString), safeString);
   });
 });


### PR DESCRIPTION
Adding tests for the `escapeChars` function. Couldn't think of a clever way to turn the `dangerChars` into a list of strings to make the test string, so it's hardcoded for now. Let me know if you think there is a more elegant way that won't require keeping the test and code in-sync. Personally, I don't mind it being explicit, but if more dangerous characters are added to the list, this won't automatically cover them.