### PR TITLE
Readme yo-yo example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ const Wrapper = styled.div`
   background: #F1F1F1;
 `;
 
-const Header = styled(yo`
+const Header = () => styled(yo`
   <header>A Header</header>
 `)`
   color: #333;


### PR DESCRIPTION
When running the README yo-yo example, the code throws `Uncaught TypeError: Header is not a function` when rendering.

To fix I made `Header` a function.

See Issue https://github.com/styled-components/styled-elements/issues/2
